### PR TITLE
Use dateparser library for most date parsing.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "timeturner"
-version = "1.8.0"
+version = "2.0.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,6 +19,12 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
 name = "autocfg"
@@ -31,15 +46,15 @@ checksum = "487f1e0fcbe47deb8b0574e646def1c903389d95241dd1bbcc6ce4a715dfc0c1"
 
 [[package]]
 name = "bumpalo"
-version = "3.11.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "cc"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cfg-if"
@@ -63,42 +78,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "chrono-english"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73d909da7eb4a7d88c679c3f5a1bc09d965754e0adb2e7627426cef96a00d6f"
-dependencies = [
- "chrono",
- "scanlex",
-]
-
-[[package]]
-name = "chrono-tz"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa48fa079165080f11d7753fd0bc175b7d391f276b965fe4b55bfad67856e463"
-dependencies = [
- "chrono",
- "chrono-tz-build",
- "phf",
-]
-
-[[package]]
-name = "chrono-tz-build"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9998fb9f7e9b2111641485bf8beb32f92945f97f92a3d061f744cfef335f751"
-dependencies = [
- "parse-zoneinfo",
- "phf",
- "phf_codegen",
-]
-
-[[package]]
 name = "clap"
-version = "4.1.11"
+version = "4.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42dfd32784433290c51d92c438bb72ea5063797fc3cc9a21a8c4346bebbb2098"
+checksum = "76e21918af71fb4bcd813230cf549e33d14f73d0326b932b630ce2930332b131"
 dependencies = [
  "bitflags 2.0.2",
  "clap_derive",
@@ -111,22 +94,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.1.9"
+version = "4.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fddf67631444a3a3e3e5ac51c36a5e01335302de677bd78759eaa90ab1f46644"
+checksum = "9a932373bab67b984c790ddf2c9ca295d8e3af3b7ef92de5a5bacdccdee4b09b"
 dependencies = [
  "heck",
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.8",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.3.0"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
+checksum = "033f6b7a4acb1f358c742aaca805c939ee73b4c6209ae4318ec7aca81c42e646"
 dependencies = [
  "os_str_bytes",
 ]
@@ -149,9 +131,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cxx"
-version = "1.0.85"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5add3fc1717409d029b20c5b6903fc0c0b02fa6741d820054f4a2efa5e5816fd"
+checksum = "a9c00419335c41018365ddf7e4d5f1c12ee3659ddcf3e01974650ba1de73d038"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -161,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.85"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c87959ba14bc6fbc61df77c3fcfe180fc32b93538c4f1031dd802ccb5f2ff0"
+checksum = "fb8307ad413a98fff033c8545ecf133e3257747b3bae935e7602aab8aa92d4ca"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -171,24 +153,36 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 1.0.107",
+ "syn 2.0.8",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.85"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69a3e162fde4e594ed2b07d0f83c6c67b745e7f28ce58c6df5e6b6bef99dfb59"
+checksum = "edc52e2eb08915cb12596d29d55f0b5384f00d697a646dbd269b6ecb0fbd9d31"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.85"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e7e2adeb6a0d4a282e581096b06e1791532b7d576dcde5ccd9382acf55db8e6"
+checksum = "631569015d0d8d54e6c241733f944042623ab6df7bc3be7466874b05fcdb1c5f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.8",
+]
+
+[[package]]
+name = "dateparser"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e12a21fe97a29f5ae9cb6770419711f180d3715a039b500b5ff7ab45bb00c4"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]
@@ -214,18 +208,15 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.2.6"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "humantime"
@@ -235,16 +226,16 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.53"
+version = "0.1.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+checksum = "0c17cc76786e99f8d2f055c11159e7f0091c42474dcc3189fbab96072e873e6d"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "winapi",
+ "windows",
 ]
 
 [[package]]
@@ -259,19 +250,20 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.3"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
+checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
 dependencies = [
+ "hermit-abi",
  "libc",
  "windows-sys",
 ]
 
 [[package]]
 name = "is-terminal"
-version = "0.4.2"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+checksum = "8687c819457e979cc940d09cb16e42a1bf70aa6b60a549de6d3a62a0ee90c69e"
 dependencies = [
  "hermit-abi",
  "io-lifetimes",
@@ -281,24 +273,30 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.139"
+name = "lazy_static"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "libc"
+version = "0.2.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "link-cplusplus"
@@ -325,6 +323,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,92 +349,21 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "os_str_bytes"
-version = "6.4.1"
+version = "6.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
-
-[[package]]
-name = "parse-zoneinfo"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c705f256449c60da65e11ff6626e0c16a0a0b96aaa348de61376b249bc340f41"
-dependencies = [
- "regex",
-]
-
-[[package]]
-name = "phf"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928c6535de93548188ef63bb7c4036bd415cd8f36ad25af44b9789b2ee72a48c"
-dependencies = [
- "phf_shared",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56ac890c5e3ca598bbdeaa99964edb5b0258a583a9eb6ef4e89fc85d9224770"
-dependencies = [
- "phf_generator",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1181c94580fa345f50f19d738aaa39c0ed30a600d95cb2d3e23f94266f14fbf"
-dependencies = [
- "phf_shared",
- "rand",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1fb5f6f826b772a8d4c0394209441e7d37cbbb967ae9c7e0e8134365c9ee676"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.107",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
+checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.52"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
+checksum = "ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73"
 dependencies = [
  "unicode-ident",
 ]
@@ -445,40 +378,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-
-[[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+checksum = "cce168fea28d3e05f158bda4576cf0c844d5045bc2cc3620fa0292ed5bb5814c"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.28"
+version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "rustix"
-version = "0.36.5"
+version = "0.36.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3807b5d10909833d3e9acd1eb5fb988f79376ff10fce42937de71a449c4c588"
+checksum = "db4165c9963ab29e422d6c26fbc1d37f15bace6b2810221f9d925023480fcf0e"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
@@ -490,21 +410,15 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
-
-[[package]]
-name = "scanlex"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "088c5d71572124929ea7549a8ce98e1a6fd33d0a38367b09027b382e67c033db"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "scratch"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
+checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
 
 [[package]]
 name = "serde"
@@ -523,7 +437,7 @@ checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.3",
+ "syn 2.0.8",
 ]
 
 [[package]]
@@ -538,12 +452,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "siphasher"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
-
-[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,9 +459,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -562,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.3"
+version = "2.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8234ae35e70582bfa0f1fedffa6daa248e41dd045310b19800c4a36382c8f60"
+checksum = "bcc02725fd69ab9f26eab07fad303e2497fad6fb9eba4f96c4d1687bdf704ad9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -573,9 +481,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
 ]
@@ -596,9 +504,8 @@ name = "timeturner"
 version = "1.8.0"
 dependencies = [
  "chrono",
- "chrono-english",
- "chrono-tz",
  "clap",
+ "dateparser",
  "humantime",
  "serde",
  "serde_json",
@@ -606,21 +513,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"
@@ -630,9 +531,9 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -640,24 +541,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -665,22 +566,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "winapi"
@@ -714,10 +615,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-sys"
-version = "0.42.0"
+name = "windows"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+checksum = "cdacb41e6a96a052c6cb63a144f24900236121c6f63f4f8219fef5977ecb0c25"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -730,42 +649,42 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "timeturner"
 version = "1.8.0"
 authors = ["Stephen Duncan <jrduncans@users.noreply.github.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Command line utility for manipulating date-time strings"
 repository = "https://github.com/jrduncans/timeturner"
@@ -14,10 +14,9 @@ categories = ["command-line-utilities", "date-and-time", "value-formatting"]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-clap = { version = "4.1.11", features = ["derive"] }
 chrono = "0.4.24"
-chrono-tz = "0.8.1"
+clap = { version = "4.1.12", features = ["derive"] }
 serde = { version = "1.0.158", features = ["derive"] }
 serde_json = "1.0.94"
-chrono-english = "0.1.7"
 humantime = "2.1.0"
+dateparser = "0.1.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "timeturner"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Stephen Duncan <jrduncans@users.noreply.github.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To install with **cargo**:
 
 `cargo install timeturner`
 
-For use in **Alfred** download the [latest release](https://github.com/jrduncans/timeturner/releases/download/v1.8.0/timeturner.alfredworkflow)
+For use in **Alfred** download the [latest release](https://github.com/jrduncans/timeturner/releases/download/v2.0.0/timeturner.alfredworkflow)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -18,39 +18,40 @@ For use in **Alfred** download the [latest release](https://github.com/jrduncans
 
 `timeturner 1575149020890`
 
-> 2019-11-30T21:23:40.890Z
->
-> 2019-11-30T13:23:40.890-08:00
->
-> 1year 1month 28days 11h 15m 59s 32ms ago
+```text
+2019-11-30T21:23:40.890Z
+2019-11-30T13:23:40.890-08:00
+1575149020890
+3years 3months 21days 22h 29m 35s 867ms ago
+```
 
 `timeturner 2019-11-30T13:27:45-08:00`
 
-> 2019-11-30T21:27:45.000Z
->
-> 1575149265000
->
-> 1year 1month 28days 11h 12m 24s 33ms ag
+```text
+2019-11-30T21:27:45.000Z
+2019-11-30T13:27:45.000-08:00
+1575149265000
+3years 3months 21days 22h 29m 13s 981ms ago
+```
 
 `timeturner '03 Feb 2020 01:03:10.534'`
 
-> 2020-02-03T01:03:10.534Z
->
-> 2020-02-02T17:03:10.534-08:00
->
-> 1580691790534
->
-> 11months 25days 4h 1m 14s 858ms ago
+```text
+2020-02-03T01:03:10.534Z
+2020-02-02T17:03:10.534-08:00
+1580691790534
+3years 1month 18days 16h 1m 26s 481ms ago
+```
 
 `timeturner 1575149020890 -d days`
 
-> 2019-11-30T21:23:40.890Z
->
-> 2019-11-30T13:23:40.890-08:00
->
-> 1year 2months 23days 3h 52m 12s 74ms ago
->
-> 449.3 days ago
+```text
+2019-11-30T21:23:40.890Z
+2019-11-30T13:23:40.890-08:00
+1575149020890
+3years 3months 21days 22h 34m 3s 15ms ago
+1209.0 days ago
+```
 
 ## Alfred Usage
 

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -1,127 +1,29 @@
 use chrono::prelude::*;
-use chrono_english::{parse_date_string, Dialect};
+use dateparser::parse_with;
 
-#[derive(PartialEq, Eq, Debug)]
-pub enum DateTimeFormat {
-    Missing,
-    EpochMillis,
-    Rfc3339,
-    CustomUnzoned,
-    CustomZoned,
-    English,
-}
+const CUSTOM_UNZONED_FORMATS: [&str; 3] = ["%F %T,%3f", "%d %b %Y %H:%M:%S,%3f", "%T%.3f UTC %F"];
 
-impl DateTimeFormat {
-    fn parse(&self, input: &str) -> Option<ParsedInput> {
-        match self {
-            Self::Missing => None,
-            Self::EpochMillis => parse_from_epoch_millis(input),
-            Self::Rfc3339 => parse_from_rfc3339(input),
-            Self::CustomUnzoned => parse_custom_unzoned_format(input),
-            Self::CustomZoned => parse_custom_zoned_format(input),
-            Self::English => parse_from_english(input),
-        }
-    }
-}
-
-#[derive(PartialEq, Eq, Debug)]
-pub struct ParsedInput {
-    pub input_format: DateTimeFormat,
-    pub input_zone: Option<FixedOffset>,
-    pub value: DateTime<Utc>,
-}
-
-fn parse_from_epoch_millis(input: &str) -> Option<ParsedInput> {
-    input
-        .parse::<i64>()
-        .ok()
-        .and_then(|e| Utc.timestamp_millis_opt(e).single())
-        .map(|d| ParsedInput {
-            input_format: DateTimeFormat::EpochMillis,
-            input_zone: None,
-            value: d,
-        })
-}
-
-fn parse_from_rfc3339(input: &str) -> Option<ParsedInput> {
-    DateTime::parse_from_rfc3339(&input.replace(' ', "T"))
-        .ok()
-        .map(|d| ParsedInput {
-            input_format: DateTimeFormat::Rfc3339,
-            input_zone: Some(d.timezone()),
-            value: d.with_timezone(&Utc),
-        })
-}
-
-const CUSTOM_UNZONED_FORMATS: [&str; 6] = [
-    "%F %T,%3f",
-    "%d %b %Y %H:%M:%S%.3f",
-    "%d %b %Y %H:%M:%S,%3f",
-    "%F %T%.3f UTC",
-    "%T%.3f UTC %F",
-    "%F %T%.6f",
-];
-
-fn parse_custom_unzoned_format(input: &str) -> Option<ParsedInput> {
+fn parse_custom_unzoned_format(input: &str) -> Option<DateTime<Utc>> {
     CUSTOM_UNZONED_FORMATS
         .iter()
         .find_map(|s| parse_from_format_unzoned(input, s))
 }
 
-fn parse_from_format_unzoned(input: &str, format: &str) -> Option<ParsedInput> {
-    Utc.datetime_from_str(input, format)
-        .ok()
-        .map(|d| ParsedInput {
-            input_format: DateTimeFormat::CustomUnzoned,
-            input_zone: None,
-            value: d.with_timezone(&Utc),
-        })
+fn parse_from_format_unzoned(input: &str, format: &str) -> Option<DateTime<Utc>> {
+    Utc.datetime_from_str(input, format).ok()
 }
 
-const CUSTOM_ZONED_FORMATS: [&str; 2] = ["%F %T%z", "%F %T%.3f%z"];
-
-fn parse_custom_zoned_format(input: &str) -> Option<ParsedInput> {
-    CUSTOM_ZONED_FORMATS
-        .iter()
-        .find_map(|s| parse_from_format_zoned(input, s))
+fn parse_with_dateparser(input: &str) -> Option<DateTime<Utc>> {
+    let midnight = NaiveTime::from_hms_opt(0, 0, 0).unwrap();
+    parse_with(input, &Utc, midnight).ok()
 }
 
-fn parse_from_format_zoned(input: &str, format: &str) -> Option<ParsedInput> {
-    DateTime::parse_from_str(input, format)
-        .ok()
-        .map(|d| ParsedInput {
-            input_format: DateTimeFormat::CustomZoned,
-            input_zone: Some(d.timezone()),
-            value: d.with_timezone(&Utc),
-        })
-}
-
-fn parse_from_english(input: &str) -> Option<ParsedInput> {
-    parse_date_string(input, Local::now(), Dialect::Us)
-        .ok()
-        .map(|d| ParsedInput {
-            input_format: DateTimeFormat::English,
-            input_zone: None,
-            value: d.with_timezone(&Utc),
-        })
-}
-
-pub fn parse_input(input: &Option<String>) -> Result<ParsedInput, &'static str> {
+pub fn parse_input(input: &Option<String>) -> Result<DateTime<Utc>, &'static str> {
     input.as_ref().filter(|i| !i.trim().is_empty()).map_or_else(
-        || {
-            Ok(ParsedInput {
-                input_format: DateTimeFormat::Missing,
-                input_zone: None,
-                value: Utc::now(),
-            })
-        },
+        || Ok(Utc::now()),
         |i| {
-            DateTimeFormat::EpochMillis
-                .parse(i)
-                .or_else(|| DateTimeFormat::Rfc3339.parse(i))
-                .or_else(|| DateTimeFormat::CustomZoned.parse(i))
-                .or_else(|| DateTimeFormat::CustomUnzoned.parse(i))
-                .or_else(|| DateTimeFormat::English.parse(i))
+            parse_with_dateparser(i)
+                .or_else(|| parse_custom_unzoned_format(i))
                 .ok_or("Input format not recognized")
         },
     )
@@ -137,20 +39,14 @@ mod tests {
     fn missing_input() {
         let now = Utc::now();
         let result = parse_input(&None).unwrap();
-        assert_eq!(result.input_format, crate::parsing::DateTimeFormat::Missing);
-        assert_eq!(result.input_zone, None);
         assert!(
-            result.value.timestamp_millis() >= now.timestamp_millis(),
-            "Provided time {} was not after the start of the test {}",
-            result.value,
-            now
+            result.timestamp_millis() >= now.timestamp_millis(),
+            "Provided time {result} was not after the start of the test {now}"
         );
 
         assert!(
-            result.value.timestamp_millis() < now.timestamp_millis() + 1000,
-            "Provided time {} was more than one second after the start of the test {}",
-            result.value,
-            now
+            result.timestamp_millis() < now.timestamp_millis() + 1000,
+            "Provided time {result} was more than one second after the start of the test {now}"
         );
     }
 
@@ -158,175 +54,99 @@ mod tests {
     fn empty_input() {
         let now = Utc::now();
         let result = parse_input(&Some(String::from(" "))).unwrap();
-        assert_eq!(result.input_format, crate::parsing::DateTimeFormat::Missing);
-        assert_eq!(result.input_zone, None);
         assert!(
-            result.value.timestamp_millis() >= now.timestamp_millis(),
-            "Provided time {} was not after the start of the test {}",
-            result.value,
-            now
+            result.timestamp_millis() >= now.timestamp_millis(),
+            "Provided time {result} was not after the start of the test {now}"
         );
 
         assert!(
-            result.value.timestamp_millis() < now.timestamp_millis() + 1000,
-            "Provided time {} was more than one second after the start of the test {}",
-            result.value,
-            now
+            result.timestamp_millis() < now.timestamp_millis() + 1000,
+            "Provided time {result} was more than one second after the start of the test {now}"
         );
     }
 
     #[test]
     fn epoch_millis_input() {
         let result = parse_input(&Some(String::from("1572213799747"))).unwrap();
-        assert_eq!(result.input_format, DateTimeFormat::EpochMillis);
-        assert_eq!(result.input_zone, None);
-        assert_eq!(
-            result.value,
-            Utc.timestamp_millis_opt(1572213799747).unwrap()
-        );
+        assert_eq!(result, Utc.timestamp_millis_opt(1572213799747).unwrap());
     }
 
     #[test]
     fn rfc3339_input() {
         let result = parse_input(&Some(String::from("2019-10-27T15:03:19.747-07:00"))).unwrap();
-        assert_eq!(result.input_format, DateTimeFormat::Rfc3339);
-        assert_eq!(result.input_zone, FixedOffset::west_opt(25200));
-        assert_eq!(
-            result.value,
-            Utc.timestamp_millis_opt(1572213799747).unwrap()
-        );
+        assert_eq!(result, Utc.timestamp_millis_opt(1572213799747).unwrap());
     }
 
     #[test]
     fn rfc3339_input_no_partial_seconds() {
         let result = parse_input(&Some(String::from("2019-10-27T15:03:19-07:00"))).unwrap();
-        assert_eq!(result.input_format, DateTimeFormat::Rfc3339);
-        assert_eq!(result.input_zone, FixedOffset::west_opt(25200));
-        assert_eq!(
-            result.value,
-            Utc.timestamp_millis_opt(1572213799000).unwrap()
-        );
+        assert_eq!(result, Utc.timestamp_millis_opt(1572213799000).unwrap());
     }
 
     #[test]
     fn rfc3339_input_zulu() {
         let result = parse_input(&Some(String::from("2019-10-27T22:03:19.747Z"))).unwrap();
-        assert_eq!(result.input_format, DateTimeFormat::Rfc3339);
-        assert_eq!(result.input_zone, FixedOffset::west_opt(0));
-        assert_eq!(
-            result.value,
-            Utc.timestamp_millis_opt(1572213799747).unwrap()
-        );
+        assert_eq!(result, Utc.timestamp_millis_opt(1572213799747).unwrap());
     }
 
     #[test]
     fn rfc3339_input_space_instead_of_t() {
         let result = parse_input(&Some(String::from("2019-10-27 15:03:19.747-07:00"))).unwrap();
-        assert_eq!(result.input_format, DateTimeFormat::Rfc3339);
-        assert_eq!(result.input_zone, FixedOffset::west_opt(25200));
-        assert_eq!(
-            result.value,
-            Utc.timestamp_millis_opt(1572213799747).unwrap()
-        );
+        assert_eq!(result, Utc.timestamp_millis_opt(1572213799747).unwrap());
     }
 
     #[test]
     fn custom_unzoned_rfc3339_like_with_space_and_comma() {
         let result = parse_input(&Some(String::from("2020-12-17 00:00:34,247"))).unwrap();
-        assert_eq!(result.input_format, DateTimeFormat::CustomUnzoned);
-        assert_eq!(result.input_zone, None);
-        assert_eq!(
-            result.value,
-            Utc.timestamp_millis_opt(1608163234247).unwrap()
-        );
+        assert_eq!(result, Utc.timestamp_millis_opt(1608163234247).unwrap());
     }
 
     #[test]
     fn date_spelled_short_month_time_with_dot_input() {
         let result = parse_input(&Some(String::from("03 Feb 2020 01:03:10.534"))).unwrap();
-        assert_eq!(result.input_format, DateTimeFormat::CustomUnzoned);
-        assert_eq!(result.input_zone, None);
-        assert_eq!(
-            result.value,
-            Utc.timestamp_millis_opt(1580691790534).unwrap()
-        );
+        assert_eq!(result, Utc.timestamp_millis_opt(1580691790534).unwrap());
     }
 
     #[test]
     fn date_spelled_short_month_time_with_comma_input() {
         let result = parse_input(&Some(String::from("03 Feb 2020 01:03:10,534"))).unwrap();
-        assert_eq!(result.input_format, DateTimeFormat::CustomUnzoned);
-        assert_eq!(result.input_zone, None);
-        assert_eq!(
-            result.value,
-            Utc.timestamp_millis_opt(1580691790534).unwrap()
-        );
+        assert_eq!(result, Utc.timestamp_millis_opt(1580691790534).unwrap());
     }
 
     #[test]
     fn year_space_date_space_utc() {
         let result = parse_input(&Some(String::from("2019-11-22 09:03:44.00 UTC"))).unwrap();
-        assert_eq!(result.input_format, DateTimeFormat::CustomUnzoned);
-        assert_eq!(result.input_zone, None);
-        assert_eq!(
-            result.value,
-            Utc.timestamp_millis_opt(1574413424000).unwrap()
-        );
+        assert_eq!(result, Utc.timestamp_millis_opt(1574413424000).unwrap());
     }
 
     #[test]
     fn time_space_utc_space_date() {
         let result = parse_input(&Some(String::from("04:10:39 UTC 2020-02-17"))).unwrap();
-        assert_eq!(result.input_format, DateTimeFormat::CustomUnzoned);
-        assert_eq!(result.input_zone, None);
-        assert_eq!(
-            result.value,
-            Utc.timestamp_millis_opt(1581912639000).unwrap()
-        );
+        assert_eq!(result, Utc.timestamp_millis_opt(1581912639000).unwrap());
     }
 
     #[test]
     fn test_casssandra_zoned_no_millis() {
         let result = parse_input(&Some(String::from("2015-03-07 00:59:56+0100"))).unwrap();
-        assert_eq!(result.input_format, DateTimeFormat::CustomZoned);
-        assert_eq!(result.input_zone, FixedOffset::east_opt(3600));
-        assert_eq!(
-            result.value,
-            Utc.timestamp_millis_opt(1425686396000).unwrap()
-        );
+        assert_eq!(result, Utc.timestamp_millis_opt(1425686396000).unwrap());
     }
 
     #[test]
     fn test_casssandra_zoned_millis() {
         let result = parse_input(&Some(String::from("2015-03-07 00:59:56.001+0100"))).unwrap();
-        assert_eq!(result.input_format, DateTimeFormat::CustomZoned);
-        assert_eq!(result.input_zone, FixedOffset::east_opt(3600));
-        assert_eq!(
-            result.value,
-            Utc.timestamp_millis_opt(1425686396001).unwrap()
-        );
+        assert_eq!(result, Utc.timestamp_millis_opt(1425686396001).unwrap());
     }
 
     #[test]
     fn test_mysql_datetime() {
         let result = parse_input(&Some(String::from("2021-01-20 18:13:37.842000"))).unwrap();
-        assert_eq!(result.input_format, DateTimeFormat::CustomUnzoned);
-        assert_eq!(result.input_zone, None);
-        assert_eq!(
-            result.value,
-            Utc.timestamp_millis_opt(1611166417842).unwrap()
-        );
+        assert_eq!(result, Utc.timestamp_millis_opt(1611166417842).unwrap());
     }
 
     #[test]
     fn english_input() {
         let result = parse_input(&Some(String::from("May 23, 2020 12:00"))).unwrap();
-        assert_eq!(result.input_format, DateTimeFormat::English);
-        assert_eq!(result.input_zone, None);
-        assert_eq!(
-            result.value,
-            Utc.timestamp_millis_opt(1590260400000).unwrap()
-        );
+        assert_eq!(result, Utc.timestamp_millis_opt(1590235200000).unwrap());
     }
 
     #[test]


### PR DESCRIPTION
This loses knowing the input format, so now
we always output all output formats.

We also now assume UTC instead of local for
the formats that were handled by the chrono-english libary.
