### PR TITLE
improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -60,6 +69,12 @@ dependencies = [
  "once_cell_polyfill",
  "windows-sys",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "autocfg"
@@ -153,6 +168,17 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "dateparser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7c3b5f25f753dcbf8f77a535166e08cba151529b6df9be966984053a68cf39"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "regex",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -301,6 +327,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,6 +465,7 @@ version = "2.0.1"
 dependencies = [
  "chrono",
  "clap",
+ "dateparser",
  "humantime",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 4
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,12 +60,6 @@ dependencies = [
  "once_cell_polyfill",
  "windows-sys",
 ]
-
-[[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "autocfg"
@@ -170,17 +155,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "dateparser"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7c3b5f25f753dcbf8f77a535166e08cba151529b6df9be966984053a68cf39"
-dependencies = [
- "anyhow",
- "chrono",
- "regex",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,6 +219,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
 name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,35 +301,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
-
-[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,10 +356,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "speedate"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aba069c070b5e213f2a094deb7e5ed50ecb092be36102a4f4042e8d2056d060e"
+dependencies = [
+ "lexical-parse-float",
+ "strum",
+ "strum_macros",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "syn"
@@ -408,10 +410,10 @@ version = "2.0.1"
 dependencies = [
  "chrono",
  "clap",
- "dateparser",
  "humantime",
  "serde",
  "serde_json",
+ "speedate",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,6 @@ chrono = "0.4.44"
 clap = { version = "4.6.1", features = ["derive"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
+dateparser = "0.3.1"
 humantime = "2.3.0"
 speedate = "0.17.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ clap = { version = "4.6.1", features = ["derive"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 humantime = "2.3.0"
-dateparser = "0.3.1"
+speedate = "0.17.0"

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -1,16 +1,16 @@
 use chrono::prelude::*;
 use speedate::DateTime as SpeedDateTime;
 
-// Formats speedate doesn't handle: "UTC" text suffix, English month names
-const CUSTOM_UNZONED_FORMATS: [&str; 4] = [
-    "%d %b %Y %H:%M:%S%.f",
-    "%F %T%.f UTC",
-    "%T UTC %F",
-    "%B %d, %Y %H:%M",
+// Formats speedate doesn't handle; all are interpreted as UTC
+const CUSTOM_UTC_FORMATS: [&str; 4] = [
+    "%d %b %Y %H:%M:%S%.f", // 03 Feb 2020 01:03:10.534
+    "%F %T%.f UTC",          // 2019-11-22 09:03:44.00 UTC
+    "%T UTC %F",             // 04:10:39 UTC 2020-02-17
+    "%B %d, %Y %H:%M",      // May 23, 2020 12:00
 ];
 
-fn parse_custom_unzoned_format(input: &str) -> Option<DateTime<Utc>> {
-    CUSTOM_UNZONED_FORMATS.iter().find_map(|s| {
+fn parse_custom_utc_format(input: &str) -> Option<DateTime<Utc>> {
+    CUSTOM_UTC_FORMATS.iter().find_map(|s| {
         NaiveDateTime::parse_from_str(input, s)
             .ok()
             .map(|d| d.and_utc())
@@ -74,11 +74,11 @@ pub fn parse_input(input: Option<&str>) -> Result<DateTime<Utc>, &'static str> {
         || Ok(Utc::now()),
         |i| {
             parse_with_speedate(i)
-                .or_else(|| parse_custom_unzoned_format(i))
+                .or_else(|| parse_custom_utc_format(i))
                 .or_else(|| {
                     replace_comma_decimal(i).and_then(|normalized| {
                         parse_with_speedate(&normalized)
-                            .or_else(|| parse_custom_unzoned_format(&normalized))
+                            .or_else(|| parse_custom_utc_format(&normalized))
                     })
                 })
                 .ok_or("Input format not recognized")

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -4,16 +4,16 @@ use speedate::DateTime as SpeedDateTime;
 // Formats speedate doesn't handle; all are interpreted as UTC
 const CUSTOM_UTC_FORMATS: [&str; 5] = [
     "%d %b %Y %H:%M:%S%.f", // 03 Feb 2020 01:03:10.534
-    "%F %T%.f UTC",          // 2019-11-22 09:03:44.00 UTC
-    "%T UTC %F",             // 04:10:39 UTC 2020-02-17
+    "%F %T%.f UTC",         // 2019-11-22 09:03:44.00 UTC
+    "%T UTC %F",            // 04:10:39 UTC 2020-02-17
     "%B %d, %Y %H:%M",      // May 23, 2020 12:00
     "%a %b %e %T UTC %Y",   // Sun Oct 27 22:03:19 UTC 2019 (Go UnixDate)
 ];
 
 // Formats with an embedded timezone offset
 const CUSTOM_ZONED_FORMATS: [&str; 2] = [
-    "%d/%b/%Y:%T %z",        // 27/Oct/2019:22:03:19 +0000 (nginx access log)
-    "%a %b %d %Y %T GMT%z",  // Sun Oct 27 2019 22:03:19 GMT-0700 (JS Date.toString(), suffix stripped)
+    "%d/%b/%Y:%T %z",       // 27/Oct/2019:22:03:19 +0000 (nginx access log)
+    "%a %b %d %Y %T GMT%z", // Sun Oct 27 2019 22:03:19 GMT-0700 (JS Date.toString(), suffix stripped)
 ];
 
 fn parse_custom_utc_format(input: &str) -> Option<DateTime<Utc>> {
@@ -25,11 +25,9 @@ fn parse_custom_utc_format(input: &str) -> Option<DateTime<Utc>> {
 }
 
 fn parse_custom_zoned_format(input: &str) -> Option<DateTime<Utc>> {
-    CUSTOM_ZONED_FORMATS.iter().find_map(|s| {
-        DateTime::parse_from_str(input, s)
-            .ok()
-            .map(|d| d.to_utc())
-    })
+    CUSTOM_ZONED_FORMATS
+        .iter()
+        .find_map(|s| DateTime::parse_from_str(input, s).ok().map(|d| d.to_utc()))
 }
 
 // Strips " (Timezone Name)" suffix produced by JS Date.toString()
@@ -110,9 +108,7 @@ pub fn parse_input(input: Option<&str>) -> Result<DateTime<Utc>, &'static str> {
                     })
                 })
                 .or_else(|| parse_custom_zoned_format(i))
-                .or_else(|| {
-                    strip_js_tz_name(i).and_then(|s| parse_custom_zoned_format(&s))
-                })
+                .or_else(|| strip_js_tz_name(i).and_then(|s| parse_custom_zoned_format(&s)))
                 .or_else(|| parse_with_dateparser(i))
                 .ok_or("Input format not recognized")
         },

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -1,11 +1,9 @@
 use chrono::prelude::*;
 use speedate::DateTime as SpeedDateTime;
 
-// Formats speedate doesn't handle: comma decimal, "UTC" text suffix, English month names
-const CUSTOM_UNZONED_FORMATS: [&str; 6] = [
-    "%F %T,%3f",
+// Formats speedate doesn't handle: "UTC" text suffix, English month names
+const CUSTOM_UNZONED_FORMATS: [&str; 4] = [
     "%d %b %Y %H:%M:%S%.f",
-    "%d %b %Y %H:%M:%S,%3f",
     "%F %T%.f UTC",
     "%T UTC %F",
     "%B %d, %Y %H:%M",
@@ -42,6 +40,29 @@ fn speedate_to_chrono(dt: SpeedDateTime) -> Option<DateTime<Utc>> {
     })
 }
 
+fn replace_comma_decimal(input: &str) -> Option<String> {
+    let chars: Vec<char> = input.chars().collect();
+    let mut changed = false;
+    let result: String = chars
+        .iter()
+        .enumerate()
+        .map(|(i, &c)| {
+            if c == ','
+                && i > 0
+                && chars[i - 1].is_ascii_digit()
+                && i + 1 < chars.len()
+                && chars[i + 1].is_ascii_digit()
+            {
+                changed = true;
+                '.'
+            } else {
+                c
+            }
+        })
+        .collect();
+    if changed { Some(result) } else { None }
+}
+
 fn parse_with_speedate(input: &str) -> Option<DateTime<Utc>> {
     SpeedDateTime::parse_str(input)
         .ok()
@@ -54,6 +75,12 @@ pub fn parse_input(input: Option<&str>) -> Result<DateTime<Utc>, &'static str> {
         |i| {
             parse_with_speedate(i)
                 .or_else(|| parse_custom_unzoned_format(i))
+                .or_else(|| {
+                    replace_comma_decimal(i).and_then(|normalized| {
+                        parse_with_speedate(&normalized)
+                            .or_else(|| parse_custom_unzoned_format(&normalized))
+                    })
+                })
                 .ok_or("Input format not recognized")
         },
     )
@@ -159,6 +186,18 @@ mod tests {
     fn custom_unzoned_rfc3339_like_with_space_and_comma() {
         let result = parse_input(Some(&String::from("2020-12-17 00:00:34,247"))).unwrap();
         assert_eq!(result, Utc.timestamp_millis_opt(1608163234247).unwrap());
+    }
+
+    #[test]
+    fn rfc3339_input_comma_decimal_zulu() {
+        let result = parse_input(Some(&String::from("2019-10-27T22:03:19,747Z"))).unwrap();
+        assert_eq!(result, Utc.timestamp_millis_opt(1572213799747).unwrap());
+    }
+
+    #[test]
+    fn rfc3339_input_comma_decimal_with_offset() {
+        let result = parse_input(Some(&String::from("2019-10-27T15:03:19,747-07:00"))).unwrap();
+        assert_eq!(result, Utc.timestamp_millis_opt(1572213799747).unwrap());
     }
 
     #[test]

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -1,29 +1,58 @@
 use chrono::prelude::*;
-use dateparser::parse_with;
+use speedate::DateTime as SpeedDateTime;
 
-const CUSTOM_UNZONED_FORMATS: [&str; 3] = ["%F %T,%3f", "%d %b %Y %H:%M:%S,%3f", "%T%.3f UTC %F"];
+// Formats speedate doesn't handle: comma decimal, "UTC" text suffix, English month names
+const CUSTOM_UNZONED_FORMATS: [&str; 6] = [
+    "%F %T,%3f",
+    "%d %b %Y %H:%M:%S%.f",
+    "%d %b %Y %H:%M:%S,%3f",
+    "%F %T%.f UTC",
+    "%T UTC %F",
+    "%B %d, %Y %H:%M",
+];
 
 fn parse_custom_unzoned_format(input: &str) -> Option<DateTime<Utc>> {
-    CUSTOM_UNZONED_FORMATS
-        .iter()
-        .find_map(|s| parse_from_format_unzoned(input, s))
+    CUSTOM_UNZONED_FORMATS.iter().find_map(|s| {
+        NaiveDateTime::parse_from_str(input, s)
+            .ok()
+            .map(|d| d.and_utc())
+    })
 }
 
-fn parse_from_format_unzoned(input: &str, format: &str) -> Option<DateTime<Utc>> {
-    NaiveDateTime::parse_from_str(input, format)
-        .map(|d| d.and_utc())
+fn speedate_to_chrono(dt: SpeedDateTime) -> Option<DateTime<Utc>> {
+    let naive = NaiveDateTime::new(
+        NaiveDate::from_ymd_opt(
+            dt.date.year.into(),
+            dt.date.month.into(),
+            dt.date.day.into(),
+        )?,
+        NaiveTime::from_hms_micro_opt(
+            dt.time.hour.into(),
+            dt.time.minute.into(),
+            dt.time.second.into(),
+            dt.time.microsecond,
+        )?,
+    );
+    Some(match dt.time.tz_offset {
+        Some(offset_secs) => FixedOffset::east_opt(offset_secs)?
+            .from_local_datetime(&naive)
+            .single()?
+            .to_utc(),
+        None => naive.and_utc(),
+    })
+}
+
+fn parse_with_speedate(input: &str) -> Option<DateTime<Utc>> {
+    SpeedDateTime::parse_str(input)
         .ok()
-}
-
-fn parse_with_dateparser(input: &str) -> Option<DateTime<Utc>> {
-    parse_with(input, &Utc, NaiveTime::MIN).ok()
+        .and_then(speedate_to_chrono)
 }
 
 pub fn parse_input(input: Option<&str>) -> Result<DateTime<Utc>, &'static str> {
     input.filter(|i| !i.trim().is_empty()).map_or_else(
         || Ok(Utc::now()),
         |i| {
-            parse_with_dateparser(i)
+            parse_with_speedate(i)
                 .or_else(|| parse_custom_unzoned_format(i))
                 .ok_or("Input format not recognized")
         },
@@ -93,6 +122,36 @@ mod tests {
     #[test]
     fn rfc3339_input_space_instead_of_t() {
         let result = parse_input(Some(&String::from("2019-10-27 15:03:19.747-07:00"))).unwrap();
+        assert_eq!(result, Utc.timestamp_millis_opt(1572213799747).unwrap());
+    }
+
+    #[test]
+    fn rfc3339_input_lowercase_t() {
+        let result = parse_input(Some(&String::from("2019-10-27t15:03:19.747-07:00"))).unwrap();
+        assert_eq!(result, Utc.timestamp_millis_opt(1572213799747).unwrap());
+    }
+
+    #[test]
+    fn rfc3339_no_offset_assumed_utc() {
+        let result = parse_input(Some(&String::from("2019-10-27T22:03:19.747"))).unwrap();
+        assert_eq!(result, Utc.timestamp_millis_opt(1572213799747).unwrap());
+    }
+
+    #[test]
+    fn rfc3339_no_offset_no_millis_assumed_utc() {
+        let result = parse_input(Some(&String::from("2019-10-27T22:03:19"))).unwrap();
+        assert_eq!(result, Utc.timestamp_millis_opt(1572213799000).unwrap());
+    }
+
+    #[test]
+    fn rfc3339_lowercase_t_no_offset_assumed_utc() {
+        let result = parse_input(Some(&String::from("2019-10-27t22:03:19.747"))).unwrap();
+        assert_eq!(result, Utc.timestamp_millis_opt(1572213799747).unwrap());
+    }
+
+    #[test]
+    fn rfc3339_space_separator_no_offset_assumed_utc() {
+        let result = parse_input(Some(&String::from("2019-10-27 22:03:19.747"))).unwrap();
         assert_eq!(result, Utc.timestamp_millis_opt(1572213799747).unwrap());
     }
 

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -2,11 +2,18 @@ use chrono::prelude::*;
 use speedate::DateTime as SpeedDateTime;
 
 // Formats speedate doesn't handle; all are interpreted as UTC
-const CUSTOM_UTC_FORMATS: [&str; 4] = [
+const CUSTOM_UTC_FORMATS: [&str; 5] = [
     "%d %b %Y %H:%M:%S%.f", // 03 Feb 2020 01:03:10.534
     "%F %T%.f UTC",          // 2019-11-22 09:03:44.00 UTC
     "%T UTC %F",             // 04:10:39 UTC 2020-02-17
     "%B %d, %Y %H:%M",      // May 23, 2020 12:00
+    "%a %b %e %T UTC %Y",   // Sun Oct 27 22:03:19 UTC 2019 (Go UnixDate)
+];
+
+// Formats with an embedded timezone offset
+const CUSTOM_ZONED_FORMATS: [&str; 2] = [
+    "%d/%b/%Y:%T %z",        // 27/Oct/2019:22:03:19 +0000 (nginx access log)
+    "%a %b %d %Y %T GMT%z",  // Sun Oct 27 2019 22:03:19 GMT-0700 (JS Date.toString(), suffix stripped)
 ];
 
 fn parse_custom_utc_format(input: &str) -> Option<DateTime<Utc>> {
@@ -15,6 +22,23 @@ fn parse_custom_utc_format(input: &str) -> Option<DateTime<Utc>> {
             .ok()
             .map(|d| d.and_utc())
     })
+}
+
+fn parse_custom_zoned_format(input: &str) -> Option<DateTime<Utc>> {
+    CUSTOM_ZONED_FORMATS.iter().find_map(|s| {
+        DateTime::parse_from_str(input, s)
+            .ok()
+            .map(|d| d.to_utc())
+    })
+}
+
+// Strips " (Timezone Name)" suffix produced by JS Date.toString()
+fn strip_js_tz_name(input: &str) -> Option<String> {
+    if input.ends_with(')') {
+        input.rfind(" (").map(|pos| input[..pos].to_string())
+    } else {
+        None
+    }
 }
 
 fn speedate_to_chrono(dt: SpeedDateTime) -> Option<DateTime<Utc>> {
@@ -63,6 +87,10 @@ fn replace_comma_decimal(input: &str) -> Option<String> {
     if changed { Some(result) } else { None }
 }
 
+fn parse_with_dateparser(input: &str) -> Option<DateTime<Utc>> {
+    dateparser::parse_with_timezone(input, &Utc).ok()
+}
+
 fn parse_with_speedate(input: &str) -> Option<DateTime<Utc>> {
     SpeedDateTime::parse_str(input)
         .ok()
@@ -81,6 +109,11 @@ pub fn parse_input(input: Option<&str>) -> Result<DateTime<Utc>, &'static str> {
                             .or_else(|| parse_custom_utc_format(&normalized))
                     })
                 })
+                .or_else(|| parse_custom_zoned_format(i))
+                .or_else(|| {
+                    strip_js_tz_name(i).and_then(|s| parse_custom_zoned_format(&s))
+                })
+                .or_else(|| parse_with_dateparser(i))
                 .ok_or("Input format not recognized")
         },
     )
@@ -252,5 +285,64 @@ mod tests {
     fn invalid_input() {
         let result = parse_input(Some(&String::from("not a date"))).err();
         assert_eq!(result, Some("Input format not recognized"));
+    }
+
+    // nginx/Apache combined access log: 27/Oct/2019:22:03:19 +0000
+    #[test]
+    fn nginx_access_log_format() {
+        let result = parse_input(Some(&String::from("27/Oct/2019:22:03:19 +0000"))).unwrap();
+        assert_eq!(result, Utc.timestamp_millis_opt(1572213799000).unwrap());
+    }
+
+    #[test]
+    fn nginx_access_log_format_nonzero_offset() {
+        let result = parse_input(Some(&String::from("27/Oct/2019:15:03:19 -0700"))).unwrap();
+        assert_eq!(result, Utc.timestamp_millis_opt(1572213799000).unwrap());
+    }
+
+    // HTTP date (RFC 7231): always GMT
+    #[test]
+    fn http_date_rfc7231() {
+        let result = parse_input(Some(&String::from("Sun, 27 Oct 2019 22:03:19 GMT"))).unwrap();
+        assert_eq!(result, Utc.timestamp_millis_opt(1572213799000).unwrap());
+    }
+
+    // RFC 2822 with numeric offset
+    #[test]
+    fn rfc2822_numeric_utc_offset() {
+        let result = parse_input(Some(&String::from("Sun, 27 Oct 2019 22:03:19 +0000"))).unwrap();
+        assert_eq!(result, Utc.timestamp_millis_opt(1572213799000).unwrap());
+    }
+
+    #[test]
+    fn rfc2822_nonzero_offset() {
+        let result = parse_input(Some(&String::from("Sun, 27 Oct 2019 15:03:19 -0700"))).unwrap();
+        assert_eq!(result, Utc.timestamp_millis_opt(1572213799000).unwrap());
+    }
+
+    // Go UnixDate / output of Unix `date` command: Sun Oct 27 22:03:19 UTC 2019
+    #[test]
+    fn go_unix_date_format() {
+        let result = parse_input(Some(&String::from("Sun Oct 27 22:03:19 UTC 2019"))).unwrap();
+        assert_eq!(result, Utc.timestamp_millis_opt(1572213799000).unwrap());
+    }
+
+    // JavaScript Date.toString(): Sun Oct 27 2019 22:03:19 GMT+0000 (Coordinated Universal Time)
+    #[test]
+    fn javascript_date_tostring_utc() {
+        let result = parse_input(Some(&String::from(
+            "Sun Oct 27 2019 22:03:19 GMT+0000 (Coordinated Universal Time)",
+        )))
+        .unwrap();
+        assert_eq!(result, Utc.timestamp_millis_opt(1572213799000).unwrap());
+    }
+
+    #[test]
+    fn javascript_date_tostring_nonzero_offset() {
+        let result = parse_input(Some(&String::from(
+            "Sun Oct 27 2019 15:03:19 GMT-0700 (Pacific Daylight Time)",
+        )))
+        .unwrap();
+        assert_eq!(result, Utc.timestamp_millis_opt(1572213799000).unwrap());
     }
 }


### PR DESCRIPTION
- **Replace dateparser with speedate for full RFC 3339 support**
- **Generalize comma-as-decimal support via normalization instead of format strings**
- **Rename custom format constant and add inline examples**
- **Add dateparser fallback and support nginx, Go UnixDate, JS Date.toString(), RFC 2822, and HTTP date formats**
